### PR TITLE
use async script injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,17 @@ module.exports = function (options) {
     return injector(function (req, res) {
         return (res.getHeader('content-type') || '').indexOf('text/html') > -1;
     }, function (content, req, res, callback) {
-        var scriptSrc = 'http://' + options.host + ':' + options.port + '/target/target-script-min.js#' + options.id;
+        var snippet = "<script>(function () {" +
+            "if (document.getElementById('weinre-script')) { return false; }" +
+            "var w = document.createElement('script'); " +
+            "w.id = 'weinre-script';" +
+            "w.type = 'text/javascript'; w.async = true; " +
+            "w.src = '//' + (location.host || '" + options.host + "').split(':')[0] + ':" + options.port + "/target/target-script-min.js#" + options.id + "';" +
+            "var s = document.getElementsByTagName('script')[0];" +
+            "s.parentNode.insertBefore(w, s); " +
+            "}());</script>";
 
-        content = content.toString().replace('</head>', '<script src="' + scriptSrc + '"></script></head>');
+        content = content.toString().replace('</body>', snippet + "</body>");
 
         callback(null, content);
     });

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function (options) {
             "var w = document.createElement('script'); " +
             "w.id = 'weinre-script';" +
             "w.type = 'text/javascript'; w.async = true; " +
-            "w.src = '//' + (location.host || '" + options.host + "').split(':')[0] + ':" + options.port + "/target/target-script-min.js#" + options.id + "';" +
+            "w.src = '//" + options.host + ":" + options.port + "/target/target-script-min.js#" + options.id + "';" +
             "var s = document.getElementsByTagName('script')[0];" +
             "s.parentNode.insertBefore(w, s); " +
             "}());</script>";


### PR DESCRIPTION
With this PR weinre script is injected by dynamically generating it (much like Facebook and Twitter SDKs).

This way server host URL is based on browser `location.host` which is more flexible than passing it as an option  (which anyway is used as a fallback)
